### PR TITLE
Add methods for MMIO reads and writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,63 @@
 version = 4
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "safe-mmio"
 version = "0.1.0"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79386d31a42a4996e3336b0919ddb90f81112af416270cff95b5f5af22b839c2"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76331675d372f91bf8d17e13afbd5fe639200b73d01f0fc748bb059f9cca2db7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ keywords = ["mmio"]
 categories = ["embedded", "no-std"]
 
 [dependencies]
+zerocopy = "0.8.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ keywords = ["mmio"]
 categories = ["embedded", "no-std"]
 
 [dependencies]
-zerocopy = "0.8.18"
+zerocopy = { version = "0.8.18", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -57,12 +57,11 @@ use safe_mmio::{
     UniqueMmioPointer,
 };
 
-#[repr(C, align(4))]
+#[repr(C)]
 struct UartRegisters {
     data: ReadWrite<u8>,
-    _padding: [u8; 3],
-    status: ReadPure<u32>,
-    pending_interrupt: ReadOnly<u32>,
+    status: ReadPure<u8>,
+    pending_interrupt: ReadOnly<u8>,
 }
 
 let mut uart_registers: UniqueMmioPointer<UartRegisters> =

--- a/README.md
+++ b/README.md
@@ -7,6 +7,38 @@ This crate provides types for safe MMIO device access, especially in systems wit
 
 This is not an officially supported Google product.
 
+## Comparison with other MMIO crates
+
+There are a number of things that distinguish this crate from other crates providing abstractions
+for MMIO in Rust.
+
+1. We avoid creating references to MMIO address space. The Rust compiler is free to dereference
+   references whenever it likes, so constructing references to MMIO address space (even temporarily)
+   can lead to undefined behaviour. See https://github.com/rust-embedded/volatile-register/issues/10
+   for more background on this.
+2. We distinguish between MMIO reads which have side-effects (e.g. clearing an interrupt status, or
+   popping from a queue) and those which don't (e.g. just reading some status). A read which has
+   side-effects should be treated like a write and only be allowed from a unique pointer (passed via
+   &mut) whereas a read without side-effects can safely be done via a shared pointer (passed via
+   '&'), e.g. simultaneously from multiple threads.
+3. On most platforms MMIO reads and writes can be done via `read_volatile` and `write_volatile`, but
+   on aarch64 this may generate instructions which can't be virtualised. This is arguably
+   [a bug in rustc](https://github.com/rust-lang/rust/issues/131894), but in the meantime we work
+   around this by using inline assembly to generate the correct instructions for MMIO reads and
+   writes on aarch64.
+
+| Crate name                                                      | Last release   | Version | Avoids references | Distinguishes reads with side-effects | Works around aarch64 volatile bug | Model                               | Field projection                     | Notes                                                                             |
+| --------------------------------------------------------------- | -------------- | ------- | ----------------- | ------------------------------------- | --------------------------------- | ----------------------------------- | ------------------------------------ | --------------------------------------------------------------------------------- |
+| safe-mmio                                                       | unreleased     | 0.2.0   | ✅                | ✅                                    | ✅                                | struct with field wrappers          | macro                                |
+| [derive-mmio](https://crates.io/crates/derive-mmio)             | February 2025  | 0.3.0   | ✅                | ❌                                    | ❌                                | struct with derive macro            | only one level, through derive macro |
+| [volatile](https://crates.io/crates/volatile)                   | June 2024      | 0.6.1   | ✅                | ❌                                    | ❌                                | struct with derive macro            | macro or generated methods           |
+| [volatile-register](https://crates.io/crates/volatile-register) | October 2023   | 0.2.2   | ❌                | ❌                                    | ❌                                | struct with field wrappers          | manual (references)                  |
+| [tock-registers](https://crates.io/crates/tock-registers)       | September 2023 | 0.9.0   | ❌                | ❌                                    | ❌                                | macros to define fields and structs | manual (references)                  | Also covers CPU registers, and bitfields                                          |
+| [mmio](https://crates.io/crates/mmio)                           | May 2021       | 2.1.0   | ✅                | ❌                                    | ❌                                | only deals with individual fields   | ❌                                   |
+| [rumio](https://crates.io/crates/rumio)                         | March 2021     | 0.2.0   | ✅                | ❌                                    | ❌                                | macros to define fields and structs | generated methods                    | Also covers CPU registers, and bitfields                                          |
+| [vcell](https://crates.io/crates/vcell)                         | January 2021   | 0.1.3   | ❌                | ❌                                    | ❌                                | plain struct                        | manual (references)                  |
+| [register](https://crates.io/crates/register)                   | January 2021   | 1.0.2   | ❌                | ❌                                    | ❌                                | macros to define fields and structs | manual (references)                  | Deprecated in favour of tock-registers. Also covers CPU registers, and bitfields. |
+
 ## License
 
 Licensed under either of

--- a/src/aarch64_mmio.rs
+++ b/src/aarch64_mmio.rs
@@ -1,0 +1,42 @@
+// Copyright 2025 The safe-mmio Authors.
+// This project is dual-licensed under Apache 2.0 and MIT terms.
+// See LICENSE-APACHE and LICENSE-MIT for details.
+
+macro_rules! asm_mmio {
+    ($t:ty, $read_assembly:literal, $write_assembly:literal) => {
+        impl $crate::OwnedMmioPointer<'_, $t> {
+            #[doc = "Performs an MMIO read of the "]
+            #[doc = stringify!($t)]
+            #[doc = "."]
+            pub fn read(&self) -> $t {
+                let value;
+                unsafe {
+                    core::arch::asm!(
+                        $read_assembly,
+                        value = out(reg) value,
+                        ptr = in(reg) self.regs.as_ptr(),
+                    );
+                }
+                value
+            }
+
+            #[doc = "Performs an MMIO write of the "]
+            #[doc = stringify!($t)]
+            #[doc = "."]
+            pub fn write(&mut self, value: $t) {
+                unsafe {
+                    core::arch::asm!(
+                        $write_assembly,
+                        value = in(reg) value,
+                        ptr = in(reg) self.regs.as_ptr(),
+                    );
+                }
+            }
+        }
+    };
+}
+
+asm_mmio!(u8, "ldrb {value:w}, [{ptr}]", "strb {value:w}, [{ptr}]");
+asm_mmio!(u16, "ldrh {value:w}, [{ptr}]", "strh {value:w}, [{ptr}]");
+asm_mmio!(u32, "ldr {value:w}, [{ptr}]", "str {value:w}, [{ptr}]");
+asm_mmio!(u64, "ldr {value:x}, [{ptr}]", "str {value:x}, [{ptr}]");

--- a/src/aarch64_mmio.rs
+++ b/src/aarch64_mmio.rs
@@ -37,6 +37,10 @@ macro_rules! asm_mmio {
 }
 
 asm_mmio!(u8, "ldrb {value:w}, [{ptr}]", "strb {value:w}, [{ptr}]");
+asm_mmio!(i8, "ldrb {value:w}, [{ptr}]", "strb {value:w}, [{ptr}]");
 asm_mmio!(u16, "ldrh {value:w}, [{ptr}]", "strh {value:w}, [{ptr}]");
+asm_mmio!(i16, "ldrh {value:w}, [{ptr}]", "strh {value:w}, [{ptr}]");
 asm_mmio!(u32, "ldr {value:w}, [{ptr}]", "str {value:w}, [{ptr}]");
+asm_mmio!(i32, "ldr {value:w}, [{ptr}]", "str {value:w}, [{ptr}]");
 asm_mmio!(u64, "ldr {value:x}, [{ptr}]", "str {value:x}, [{ptr}]");
+asm_mmio!(i64, "ldr {value:x}, [{ptr}]", "str {value:x}, [{ptr}]");

--- a/src/aarch64_mmio.rs
+++ b/src/aarch64_mmio.rs
@@ -2,45 +2,149 @@
 // This project is dual-licensed under Apache 2.0 and MIT terms.
 // See LICENSE-APACHE and LICENSE-MIT for details.
 
-macro_rules! asm_mmio {
-    ($t:ty, $read_assembly:literal, $write_assembly:literal) => {
-        impl $crate::OwnedMmioPointer<'_, $t> {
-            #[doc = "Performs an MMIO read of the "]
-            #[doc = stringify!($t)]
-            #[doc = "."]
-            pub fn read(&self) -> $t {
-                let value;
-                unsafe {
-                    core::arch::asm!(
-                        $read_assembly,
-                        value = out(reg) value,
-                        ptr = in(reg) self.regs.as_ptr(),
-                    );
-                }
-                value
-            }
+use crate::OwnedMmioPointer;
+use core::ptr::NonNull;
+use zerocopy::{FromBytes, Immutable, IntoBytes};
 
-            #[doc = "Performs an MMIO write of the "]
-            #[doc = stringify!($t)]
-            #[doc = "."]
-            pub fn write(&mut self, value: $t) {
-                unsafe {
-                    core::arch::asm!(
-                        $write_assembly,
-                        value = in(reg) value,
-                        ptr = in(reg) self.regs.as_ptr(),
-                    );
-                }
+macro_rules! asm_mmio {
+    ($t:ty, $read_name:ident, $read_assembly:literal, $write_name:ident, $write_assembly:literal) => {
+        unsafe fn $read_name(ptr: *const $t) -> $t {
+            let value;
+            unsafe {
+                core::arch::asm!(
+                    $read_assembly,
+                    value = out(reg) value,
+                    ptr = in(reg) ptr,
+                );
+            }
+            value
+        }
+
+        unsafe fn $write_name(ptr: *mut $t, value: $t) {
+            unsafe {
+                core::arch::asm!(
+                    $write_assembly,
+                    value = in(reg) value,
+                    ptr = in(reg) ptr,
+                );
             }
         }
     };
 }
 
-asm_mmio!(u8, "ldrb {value:w}, [{ptr}]", "strb {value:w}, [{ptr}]");
-asm_mmio!(i8, "ldrb {value:w}, [{ptr}]", "strb {value:w}, [{ptr}]");
-asm_mmio!(u16, "ldrh {value:w}, [{ptr}]", "strh {value:w}, [{ptr}]");
-asm_mmio!(i16, "ldrh {value:w}, [{ptr}]", "strh {value:w}, [{ptr}]");
-asm_mmio!(u32, "ldr {value:w}, [{ptr}]", "str {value:w}, [{ptr}]");
-asm_mmio!(i32, "ldr {value:w}, [{ptr}]", "str {value:w}, [{ptr}]");
-asm_mmio!(u64, "ldr {value:x}, [{ptr}]", "str {value:x}, [{ptr}]");
-asm_mmio!(i64, "ldr {value:x}, [{ptr}]", "str {value:x}, [{ptr}]");
+asm_mmio!(
+    u8,
+    read_u8,
+    "ldrb {value:w}, [{ptr}]",
+    write_u8,
+    "strb {value:w}, [{ptr}]"
+);
+asm_mmio!(
+    u16,
+    read_u16,
+    "ldrh {value:w}, [{ptr}]",
+    write_u16,
+    "strh {value:w}, [{ptr}]"
+);
+asm_mmio!(
+    u32,
+    read_u32,
+    "ldr {value:w}, [{ptr}]",
+    write_u32,
+    "str {value:w}, [{ptr}]"
+);
+asm_mmio!(
+    u64,
+    read_u64,
+    "ldr {value:x}, [{ptr}]",
+    write_u64,
+    "str {value:x}, [{ptr}]"
+);
+
+impl<T: FromBytes + IntoBytes> OwnedMmioPointer<'_, T> {
+    /// Performs an MMIO read and returns the value.
+    ///
+    /// If `T` is exactly 1, 2, 4 or 8 bytes long then this will be a single operation. Otherwise
+    /// it will be split into several, reading chunks as large as possible.
+    pub fn read(&self) -> T {
+        match size_of::<T>() {
+            1 => convert(unsafe { read_u8(self.regs.cast().as_ptr()) }),
+            2 => convert(unsafe { read_u16(self.regs.cast().as_ptr()) }),
+            4 => convert(unsafe { read_u32(self.regs.cast().as_ptr()) }),
+            8 => convert(unsafe { read_u64(self.regs.cast().as_ptr()) }),
+            _ => {
+                let mut value = T::new_zeroed();
+                unsafe { read_slice(self.regs.cast(), value.as_mut_bytes()) };
+                value
+            }
+        }
+    }
+}
+
+impl<T: Immutable + IntoBytes> OwnedMmioPointer<'_, T> {
+    /// Performs an MMIO write of the given value.
+    ///
+    /// If `T` is exactly 1, 2, 4 or 8 bytes long then this will be a single operation. Otherwise
+    /// it will be split into several, writing chunks as large as possible.
+    pub fn write(&self, value: T) {
+        match size_of::<T>() {
+            1 => unsafe { write_u8(self.regs.cast().as_ptr(), value.as_bytes()[0]) },
+            2 => unsafe { write_u16(self.regs.cast().as_ptr(), convert(value)) },
+            4 => unsafe { write_u32(self.regs.cast().as_ptr(), convert(value)) },
+            8 => unsafe { write_u64(self.regs.cast().as_ptr(), convert(value)) },
+            _ => unsafe { write_slice(self.regs.cast(), value.as_bytes()) },
+        }
+    }
+}
+
+fn convert<T: Immutable + IntoBytes, U: FromBytes>(value: T) -> U {
+    U::read_from_bytes(value.as_bytes()).unwrap()
+}
+
+unsafe fn write_slice(ptr: NonNull<u8>, slice: &[u8]) {
+    if let Some((first, rest)) = slice.split_at_checked(8) {
+        unsafe {
+            write_u64(ptr.cast().as_ptr(), u64::read_from_bytes(first).unwrap());
+            write_slice(ptr.add(8), rest);
+        }
+    } else if let Some((first, rest)) = slice.split_at_checked(4) {
+        unsafe {
+            write_u32(ptr.cast().as_ptr(), u32::read_from_bytes(first).unwrap());
+            write_slice(ptr.add(4), rest);
+        }
+    } else if let Some((first, rest)) = slice.split_at_checked(2) {
+        unsafe {
+            write_u16(ptr.cast().as_ptr(), u16::read_from_bytes(first).unwrap());
+            write_slice(ptr.add(2), rest);
+        }
+    } else if let [first, rest @ ..] = slice {
+        unsafe {
+            write_u8(ptr.as_ptr(), *first);
+            write_slice(ptr.add(1), rest);
+        }
+    }
+}
+
+unsafe fn read_slice(ptr: NonNull<u8>, slice: &mut [u8]) {
+    if let Some((first, rest)) = slice.split_at_mut_checked(8) {
+        unsafe {
+            read_u64(ptr.cast().as_ptr()).write_to(first).unwrap();
+            read_slice(ptr.add(8), rest);
+        }
+    } else if let Some((first, rest)) = slice.split_at_mut_checked(4) {
+        unsafe {
+            read_u32(ptr.cast().as_ptr()).write_to(first).unwrap();
+            read_slice(ptr.add(4), rest);
+        }
+    } else if let Some((first, rest)) = slice.split_at_mut_checked(2) {
+        unsafe {
+            read_u16(ptr.cast().as_ptr()).write_to(first).unwrap();
+            read_slice(ptr.add(2), rest);
+        }
+    } else if let [first, rest @ ..] = slice {
+        unsafe {
+            *first = read_u8(ptr.as_ptr());
+            read_slice(ptr.add(1), rest);
+        }
+    }
+}

--- a/src/aarch64_mmio.rs
+++ b/src/aarch64_mmio.rs
@@ -67,11 +67,13 @@ impl<T: FromBytes + IntoBytes> UniqueMmioPointer<'_, T> {
     /// If `T` is exactly 1, 2, 4 or 8 bytes long then this will be a single operation. Otherwise
     /// it will be split into several, reading chunks as large as possible.
     ///
+    /// Note that this takes `&mut self` rather than `&self` because an MMIO read may cause
+    /// side-effects that change the state of the device.
+    ///
     /// # Safety
     ///
-    /// This field must be safe to perform an MMIO read from, and doing so must not cause any
-    /// side-effects.
-    pub unsafe fn read_unsafe(&self) -> T {
+    /// This field must be safe to perform an MMIO read from.
+    pub unsafe fn read_unsafe(&mut self) -> T {
         match size_of::<T>() {
             1 => convert(unsafe { read_u8(self.regs.cast().as_ptr()) }),
             2 => convert(unsafe { read_u16(self.regs.cast().as_ptr()) }),

--- a/src/aarch64_mmio.rs
+++ b/src/aarch64_mmio.rs
@@ -2,7 +2,7 @@
 // This project is dual-licensed under Apache 2.0 and MIT terms.
 // See LICENSE-APACHE and LICENSE-MIT for details.
 
-use crate::OwnedMmioPointer;
+use crate::UniqueMmioPointer;
 use core::ptr::NonNull;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
@@ -61,7 +61,7 @@ asm_mmio!(
     "str {value:x}, [{ptr}]"
 );
 
-impl<T: FromBytes + IntoBytes> OwnedMmioPointer<'_, T> {
+impl<T: FromBytes + IntoBytes> UniqueMmioPointer<'_, T> {
     /// Performs an MMIO read and returns the value.
     ///
     /// If `T` is exactly 1, 2, 4 or 8 bytes long then this will be a single operation. Otherwise
@@ -81,7 +81,7 @@ impl<T: FromBytes + IntoBytes> OwnedMmioPointer<'_, T> {
     }
 }
 
-impl<T: Immutable + IntoBytes> OwnedMmioPointer<'_, T> {
+impl<T: Immutable + IntoBytes> UniqueMmioPointer<'_, T> {
     /// Performs an MMIO write of the given value.
     ///
     /// If `T` is exactly 1, 2, 4 or 8 bytes long then this will be a single operation. Otherwise

--- a/src/aarch64_mmio.rs
+++ b/src/aarch64_mmio.rs
@@ -66,7 +66,12 @@ impl<T: FromBytes + IntoBytes> UniqueMmioPointer<'_, T> {
     ///
     /// If `T` is exactly 1, 2, 4 or 8 bytes long then this will be a single operation. Otherwise
     /// it will be split into several, reading chunks as large as possible.
-    pub fn read(&self) -> T {
+    ///
+    /// # Safety
+    ///
+    /// This field must be safe to perform an MMIO read from, and doing so must not cause any
+    /// side-effects.
+    pub unsafe fn read_unsafe(&self) -> T {
         match size_of::<T>() {
             1 => convert(unsafe { read_u8(self.regs.cast().as_ptr()) }),
             2 => convert(unsafe { read_u16(self.regs.cast().as_ptr()) }),
@@ -86,7 +91,11 @@ impl<T: Immutable + IntoBytes> UniqueMmioPointer<'_, T> {
     ///
     /// If `T` is exactly 1, 2, 4 or 8 bytes long then this will be a single operation. Otherwise
     /// it will be split into several, writing chunks as large as possible.
-    pub fn write(&self, value: T) {
+    ///
+    /// # Safety
+    ///
+    /// This field must be safe to perform an MMIO write to.
+    pub unsafe fn write_unsafe(&self, value: T) {
         match size_of::<T>() {
             1 => unsafe { write_u8(self.regs.cast().as_ptr(), value.as_bytes()[0]) },
             2 => unsafe { write_u16(self.regs.cast().as_ptr(), convert(value)) },

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -8,28 +8,28 @@ use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 /// Wrapper for a field which may safely be read but not written. Reading may cause side-effects,
 /// changing the state of the device in some way.
-#[derive(Clone, Debug, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq)]
 #[repr(transparent)]
 pub struct ReadOnly<T>(pub T);
 
 /// Wrapper for a field which may safely be read with no side-effects but not written.
-#[derive(Clone, Debug, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq)]
 #[repr(transparent)]
 pub struct ReadPure<T>(pub T);
 
 /// Wrapper for a field which may safely be written but not read.
-#[derive(Clone, Debug, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq)]
 #[repr(transparent)]
 pub struct WriteOnly<T>(pub T);
 
 /// Wrapper for a field which may safely be written and read. Reading may cause side-effects,
 /// changing the state of the device in some way.
-#[derive(Clone, Debug, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq)]
 #[repr(transparent)]
 pub struct ReadWrite<T>(pub T);
 
 /// Wrapper for a field which may safely be written (with side-effects) and read with no
 /// side-effects.
-#[derive(Clone, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
 #[repr(transparent)]
 pub struct ReadPureWrite<T>(pub T);

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -1,0 +1,35 @@
+// Copyright 2025 The safe-mmio Authors.
+// This project is dual-licensed under Apache 2.0 and MIT terms.
+// See LICENSE-APACHE and LICENSE-MIT for details.
+
+//! Wrapper types for MMIO fields.
+
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+
+/// Wrapper for a field which may safely be read but not written. Reading may cause side-effects,
+/// changing the state of the device in some way.
+#[derive(Clone, Debug, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq)]
+#[repr(transparent)]
+pub struct ReadOnly<T>(pub T);
+
+/// Wrapper for a field which may safely be read with no side-effects but not written.
+#[derive(Clone, Debug, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq)]
+#[repr(transparent)]
+pub struct ReadPure<T>(pub T);
+
+/// Wrapper for a field which may safely be written but not read.
+#[derive(Clone, Debug, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq)]
+#[repr(transparent)]
+pub struct WriteOnly<T>(pub T);
+
+/// Wrapper for a field which may safely be written and read. Reading may cause side-effects,
+/// changing the state of the device in some way.
+#[derive(Clone, Debug, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq)]
+#[repr(transparent)]
+pub struct ReadWrite<T>(pub T);
+
+/// Wrapper for a field which may safely be written (with side-effects) and read with no
+/// side-effects.
+#[derive(Clone, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
+#[repr(transparent)]
+pub struct ReadPureWrite<T>(pub T);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,7 +252,7 @@ impl<T: ?Sized> SharedMmioPointer<'_, T> {
 // SAFETY: A `SharedMmioPointer` always originates either from a reference or from a
 // `UniqueMmioPointer`. The caller of `UniqueMmioPointer::new` promises that the MMIO registers can
 // be accessed from any thread.
-unsafe impl<T: Send + Sync> Send for SharedMmioPointer<'_, T> {}
+unsafe impl<T: ?Sized + Send + Sync> Send for SharedMmioPointer<'_, T> {}
 
 impl<'a, T: ?Sized> From<&'a T> for SharedMmioPointer<'a, T> {
     fn from(r: &'a T) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,12 +343,15 @@ mod tests {
         assert_eq!(owned_a.read(), 1);
         owned_a.write(42);
         assert_eq!(owned_a.read(), 42);
+        field!(owned, a).write(44);
+        assert_eq!(field!(owned, a).read(), 44);
 
         let mut owned_b: UniqueMmioPointer<ReadOnly<u32>> = field!(owned, b);
         assert_eq!(owned_b.read(), 2);
 
         let owned_c: UniqueMmioPointer<ReadPure<u32>> = field!(owned, c);
         assert_eq!(owned_c.read(), 3);
+        assert_eq!(field!(owned, c).read(), 3);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,14 +91,16 @@ impl<T: ?Sized> UniqueMmioPointer<'_, T> {
     }
 }
 
-impl<T: FromBytes + Immutable + IntoBytes> UniqueMmioPointer<'_, ReadWrite<T>> {
+impl<T: FromBytes + IntoBytes> UniqueMmioPointer<'_, ReadWrite<T>> {
     /// Performs an MMIO read of the entire `T`.
     pub fn read(&self) -> T {
         // SAFETY: self.regs is always a valid and unique pointer to MMIO address space, and `T`
         // being wrapped in `ReadWrite` implies that it is safe to read.
         unsafe { self.read_unsafe().0 }
     }
+}
 
+impl<T: Immutable + IntoBytes> UniqueMmioPointer<'_, ReadWrite<T>> {
     /// Performs an MMIO write of the entire `T`.
     pub fn write(&mut self, value: T) {
         // SAFETY: self.regs is always a valid and unique pointer to MMIO address space, and `T`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,17 +21,17 @@ use zerocopy::{FromBytes, Immutable, IntoBytes};
 /// Wrapper for a field which may safely be read but not written.
 #[derive(Clone, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
 #[repr(transparent)]
-pub struct ReadOnly<T>(T);
+pub struct ReadOnly<T>(pub T);
 
 /// Wrapper for a field which may safely be written but not read.
 #[derive(Clone, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
 #[repr(transparent)]
-pub struct WriteOnly<T>(T);
+pub struct WriteOnly<T>(pub T);
 
 /// Wrapper for a field which may safely be written and read.
 #[derive(Clone, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
 #[repr(transparent)]
-pub struct ReadWrite<T>(T);
+pub struct ReadWrite<T>(pub T);
 
 /// A unique owned pointer to the registers of some MMIO device.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,12 +19,12 @@ pub use physical::PhysicalInstance;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 /// Wrapper for a field which may safely be read but not written.
-#[derive(Clone, Debug, Eq, FromBytes, IntoBytes, PartialEq)]
+#[derive(Clone, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
 #[repr(transparent)]
 pub struct ReadOnly<T>(T);
 
 /// Wrapper for a field which may safely be written but not read.
-#[derive(Clone, Debug, Eq, Immutable, IntoBytes, PartialEq)]
+#[derive(Clone, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
 #[repr(transparent)]
 pub struct WriteOnly<T>(T);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,20 +16,20 @@ mod volatile_mmio;
 
 use core::{array, fmt::Debug, marker::PhantomData, ptr::NonNull};
 pub use physical::PhysicalInstance;
-use zerocopy::{FromBytes, Immutable, IntoBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 /// Wrapper for a field which may safely be read but not written.
-#[derive(Clone, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
+#[derive(Clone, Debug, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq)]
 #[repr(transparent)]
 pub struct ReadOnly<T>(pub T);
 
 /// Wrapper for a field which may safely be written but not read.
-#[derive(Clone, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
+#[derive(Clone, Debug, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq)]
 #[repr(transparent)]
 pub struct WriteOnly<T>(pub T);
 
 /// Wrapper for a field which may safely be written and read.
-#[derive(Clone, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
+#[derive(Clone, Debug, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq)]
 #[repr(transparent)]
 pub struct ReadWrite<T>(pub T);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,20 @@ impl<T> OwnedMmioPointer<'_, T> {
     pub fn ptr_mut(&mut self) -> *mut T {
         self.regs.as_ptr()
     }
+
+    /// Performs an MMIO read of the entire `T`.
+    pub fn read(&self) -> T {
+        // SAFETY: self.regs is always a valid and unique pointer to MMIO address space.
+        unsafe { self.regs.read_volatile() }
+    }
+
+    /// Performs an MMIO write of the entire `T`.
+    pub fn write(&mut self, value: T) {
+        // SAFETY: self.regs is always a valid and unique pointer to MMIO address space.
+        unsafe {
+            self.regs.write_volatile(value);
+        }
+    }
 }
 
 // SAFETY: The caller of `OwnedMmioPointer::new` promises that the MMIO registers can be accessed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,11 @@
 #![deny(clippy::undocumented_unsafe_blocks)]
 #![deny(unsafe_op_in_unsafe_fn)]
 
+#[cfg(target_arch = "aarch64")]
+mod aarch64_mmio;
 mod physical;
+#[cfg(not(target_arch = "aarch64"))]
+mod volatile_mmio;
 
 use core::{array, fmt::Debug, marker::PhantomData, ptr::NonNull};
 pub use physical::PhysicalInstance;
@@ -65,22 +69,6 @@ impl<T: ?Sized> OwnedMmioPointer<'_, T> {
     /// Returns a raw mut pointer to the MMIO registers.
     pub fn ptr_mut(&mut self) -> *mut T {
         self.regs.as_ptr()
-    }
-}
-
-impl<T> OwnedMmioPointer<'_, T> {
-    /// Performs an MMIO read of the entire `T`.
-    pub fn read(&self) -> T {
-        // SAFETY: self.regs is always a valid and unique pointer to MMIO address space.
-        unsafe { self.regs.read_volatile() }
-    }
-
-    /// Performs an MMIO write of the entire `T`.
-    pub fn write(&mut self, value: T) {
-        // SAFETY: self.regs is always a valid and unique pointer to MMIO address space.
-        unsafe {
-            self.regs.write_volatile(value);
-        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,41 +10,15 @@
 
 #[cfg(target_arch = "aarch64")]
 mod aarch64_mmio;
+pub mod fields;
 mod physical;
 #[cfg(not(target_arch = "aarch64"))]
 mod volatile_mmio;
 
+use crate::fields::{ReadOnly, ReadPure, ReadPureWrite, ReadWrite, WriteOnly};
 use core::{array, fmt::Debug, marker::PhantomData, ops::Deref, ptr::NonNull};
 pub use physical::PhysicalInstance;
-use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
-
-/// Wrapper for a field which may safely be read but not written. Reading may cause side-effects,
-/// changing the state of the device in some way.
-#[derive(Clone, Debug, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq)]
-#[repr(transparent)]
-pub struct ReadOnly<T>(pub T);
-
-/// Wrapper for a field which may safely be read with no side-effects but not written.
-#[derive(Clone, Debug, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq)]
-#[repr(transparent)]
-pub struct ReadPure<T>(pub T);
-
-/// Wrapper for a field which may safely be written but not read.
-#[derive(Clone, Debug, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq)]
-#[repr(transparent)]
-pub struct WriteOnly<T>(pub T);
-
-/// Wrapper for a field which may safely be written and read. Reading may cause side-effects,
-/// changing the state of the device in some way.
-#[derive(Clone, Debug, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq)]
-#[repr(transparent)]
-pub struct ReadWrite<T>(pub T);
-
-/// Wrapper for a field which may safely be written (with side-effects) and read with no
-/// side-effects.
-#[derive(Clone, Debug, Eq, FromBytes, Immutable, IntoBytes, PartialEq)]
-#[repr(transparent)]
-pub struct ReadPureWrite<T>(pub T);
+use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 /// A unique owned pointer to the registers of some MMIO device.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,11 @@ impl<T: ?Sized> UniqueMmioPointer<'_, T> {
     pub fn ptr_mut(&mut self) -> *mut T {
         self.0.regs.as_ptr()
     }
+
+    /// Returns a `NonNull<T>` pointer to the MMIO registers.
+    pub fn ptr_nonnull(&mut self) -> NonNull<T> {
+        self.0.regs
+    }
 }
 
 impl<T: FromBytes + IntoBytes> UniqueMmioPointer<'_, ReadWrite<T>> {

--- a/src/volatile_mmio.rs
+++ b/src/volatile_mmio.rs
@@ -1,0 +1,21 @@
+// Copyright 2025 The safe-mmio Authors.
+// This project is dual-licensed under Apache 2.0 and MIT terms.
+// See LICENSE-APACHE and LICENSE-MIT for details.
+
+use crate::OwnedMmioPointer;
+
+impl<T> OwnedMmioPointer<'_, T> {
+    /// Performs an MMIO read of the entire `T`.
+    pub fn read(&self) -> T {
+        // SAFETY: self.regs is always a valid and unique pointer to MMIO address space.
+        unsafe { self.regs.read_volatile() }
+    }
+
+    /// Performs an MMIO write of the entire `T`.
+    pub fn write(&mut self, value: T) {
+        // SAFETY: self.regs is always a valid and unique pointer to MMIO address space.
+        unsafe {
+            self.regs.write_volatile(value);
+        }
+    }
+}

--- a/src/volatile_mmio.rs
+++ b/src/volatile_mmio.rs
@@ -9,14 +9,16 @@ impl<T> UniqueMmioPointer<'_, T> {
     ///
     /// # Safety
     ///
-    /// This field must be safe to perform an MMIO read from, and doing so must not cause any
-    /// side-effects.
-    pub unsafe fn read_unsafe(&self) -> T {
+    /// This field must be safe to perform an MMIO read from.
+    pub unsafe fn read_unsafe(&mut self) -> T {
         // SAFETY: self.regs is always a valid and unique pointer to MMIO address space.
         unsafe { self.regs.read_volatile() }
     }
 
     /// Performs an MMIO write of the entire `T`.
+    ///
+    /// Note that this takes `&mut self` rather than `&self` because an MMIO read may cause
+    /// side-effects that change the state of the device.
     ///
     /// # Safety
     ///

--- a/src/volatile_mmio.rs
+++ b/src/volatile_mmio.rs
@@ -2,7 +2,7 @@
 // This project is dual-licensed under Apache 2.0 and MIT terms.
 // See LICENSE-APACHE and LICENSE-MIT for details.
 
-use crate::UniqueMmioPointer;
+use crate::{SharedMmioPointer, UniqueMmioPointer};
 
 impl<T> UniqueMmioPointer<'_, T> {
     /// Performs an MMIO read of the entire `T`.
@@ -28,5 +28,18 @@ impl<T> UniqueMmioPointer<'_, T> {
         unsafe {
             self.regs.write_volatile(value);
         }
+    }
+}
+
+impl<T> SharedMmioPointer<'_, T> {
+    /// Performs an MMIO read of the entire `T`.
+    ///
+    /// # Safety
+    ///
+    /// This field must be safe to perform an MMIO read from, and doing so must not cause any
+    /// side-effects.
+    pub unsafe fn read_unsafe(&self) -> T {
+        // SAFETY: self.regs is always a valid and unique pointer to MMIO address space.
+        unsafe { self.regs.read_volatile() }
     }
 }

--- a/src/volatile_mmio.rs
+++ b/src/volatile_mmio.rs
@@ -2,9 +2,9 @@
 // This project is dual-licensed under Apache 2.0 and MIT terms.
 // See LICENSE-APACHE and LICENSE-MIT for details.
 
-use crate::OwnedMmioPointer;
+use crate::UniqueMmioPointer;
 
-impl<T> OwnedMmioPointer<'_, T> {
+impl<T> UniqueMmioPointer<'_, T> {
     /// Performs an MMIO read of the entire `T`.
     pub fn read(&self) -> T {
         // SAFETY: self.regs is always a valid and unique pointer to MMIO address space.

--- a/src/volatile_mmio.rs
+++ b/src/volatile_mmio.rs
@@ -6,13 +6,22 @@ use crate::UniqueMmioPointer;
 
 impl<T> UniqueMmioPointer<'_, T> {
     /// Performs an MMIO read of the entire `T`.
-    pub fn read(&self) -> T {
+    ///
+    /// # Safety
+    ///
+    /// This field must be safe to perform an MMIO read from, and doing so must not cause any
+    /// side-effects.
+    pub unsafe fn read_unsafe(&self) -> T {
         // SAFETY: self.regs is always a valid and unique pointer to MMIO address space.
         unsafe { self.regs.read_volatile() }
     }
 
     /// Performs an MMIO write of the entire `T`.
-    pub fn write(&mut self, value: T) {
+    ///
+    /// # Safety
+    ///
+    /// This field must be safe to perform an MMIO write to.
+    pub unsafe fn write_unsafe(&mut self, value: T) {
         // SAFETY: self.regs is always a valid and unique pointer to MMIO address space.
         unsafe {
             self.regs.write_volatile(value);


### PR DESCRIPTION
This adds a bunch of different methods and macros to allow safe MMIO reads and writes of individual fields. In particular:

* `get` and `split` methods on `UniqueMmioPointer<[T]>` and `UniqueMmioPointer<[T; _]>` respectively, to go from a pointer to a slice or field to pointers to the individual elements.
* A `field!` macro to go from a pointer to a struct to a pointer to an individual field. (And `field_shared!` to do the same for `SharedMmioPointer`.) If https://github.com/rust-lang/rfcs/pull/3735 gets stabilised then we could implement that instead of needing a macro.
* `OwnedMmioPointer` is renamed to `UniqueMmioPointer`, and a new type `SharedMmioPointer` is added. `SharedMmioPointer` is to `UniqueMmioPointer` as `&T` is to `&mut T`. A `SharedMmioPointer` can be created from a `UniqueMmioPointer` and can be freely cloned, but fewer operations are possible on it. `UniqueMmioPointer` also derefs to `SharedMmioPointer`.
* A variety of wrapper types for fields, indicating whether they can safely be read (with or without side-effects) or written. It is important to distinguish whether reading an MMIO register may have side-effects (e.g. clearing an interrupt status, or popping from a queue) or not, because a read that has side-effects should be treated like a write and only be allowed from a unique pointer (passed via `&mut`) whereas a read without side-effects can safely be done via a shared pointer (passed via '&'), e.g. simultaneously from multiple threads.
* For pointers to fields with the appropriate wrapper type, safe `read` and `write` methods to perform MMIO reads and writes. On most platforms this is implemented via `read_volatile` and `write_volatile` on the underlying pointer, but on aarch64 inline assembly is used instead to work around https://github.com/rust-lang/rust/issues/131894. To do this safely we require that the underlying type implement the relevant traits from zerocopy.