### PR TITLE
Small fixes around read_unafe() and write_unsafe()

### DIFF
--- a/src/aarch64_mmio.rs
+++ b/src/aarch64_mmio.rs
@@ -87,7 +87,7 @@ impl<T: Immutable + IntoBytes> UniqueMmioPointer<'_, T> {
     /// # Safety
     ///
     /// This field must be safe to perform an MMIO write to.
-    pub unsafe fn write_unsafe(&self, value: T) {
+    pub unsafe fn write_unsafe(&mut self, value: T) {
         match size_of::<T>() {
             1 => unsafe { write_u8(self.regs.cast().as_ptr(), value.as_bytes()[0]) },
             2 => unsafe { write_u16(self.regs.cast().as_ptr(), convert(value)) },

--- a/src/volatile_mmio.rs
+++ b/src/volatile_mmio.rs
@@ -7,6 +7,9 @@ use crate::{SharedMmioPointer, UniqueMmioPointer};
 impl<T> UniqueMmioPointer<'_, T> {
     /// Performs an MMIO read of the entire `T`.
     ///
+    /// Note that this takes `&mut self` rather than `&self` because an MMIO read may cause
+    /// side-effects that change the state of the device.
+    ///
     /// # Safety
     ///
     /// This field must be safe to perform an MMIO read from.
@@ -16,9 +19,6 @@ impl<T> UniqueMmioPointer<'_, T> {
     }
 
     /// Performs an MMIO write of the entire `T`.
-    ///
-    /// Note that this takes `&mut self` rather than `&self` because an MMIO read may cause
-    /// side-effects that change the state of the device.
     ///
     /// # Safety
     ///


### PR DESCRIPTION
The comment explaining the mutable self reference for `UniqueMmioPointer::read_unsafe()` in the wrong place,
in front of `write_unsafe()`. Moving it.

The signature of `UniqueMmioPointer::write_unsafe()` of the aarch64 implementation does not match one
default one: Making the self reference mutable to fix that.