### PR TITLE
Add custom MMIO backend

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,8 @@ jobs:
         run: cargo build
       - name: Test
         run: cargo test
+      - name: Test with custom-mmio
+        run: cargo test --features=custom-mmio
       - name: Run clippy
         uses: actions-rs/clippy-check@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- Added `custom-mmio` feature to allow the user of the crate to override how the underlying MMIO
+  operations are done. This may be useful for faking devices for driver tests, or for virtual
+  platforms where MMIO requires co-ordination with the hypervisor.
+
 ## 0.3.0
 
 ### Breaking changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,8 @@ keywords = ["mmio"]
 categories = ["embedded", "no-std"]
 rust-version = "1.85"
 
+[features]
+custom-mmio = []
+
 [dependencies]
 zerocopy = { version = "0.8.50", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ custom-mmio = []
 
 [dependencies]
 zerocopy = { version = "0.8.50", features = ["derive"] }
+
+[package.metadata.docs.rs]
+features = ["custom-mmio"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ unsafe {
 }
 ```
 
-Depending on your platform this will either use `write_volatile` or some platform-dependent inline
-assembly to perform the MMIO write.
+Depending on your platform this will either use `write_volatile`, some platform-dependent inline
+assembly, or a [custom backend](#custom-mmio-backend) to perform the MMIO write.
 
 ### Safe MMIO methods
 
@@ -91,6 +91,53 @@ physical address and size of the device's MMIO region, but is intended to convey
 should never be more than one `PhysicalInstance` pointer to the same device. This way your page
 table management code can take a `PhysicalInstance<T>` and return a `UniqueMmioPointer<T>` when a
 device is mapped into the page table.
+
+### Custom MMIO backend
+
+Some environments need to intercept MMIO accesses instead of letting them hit
+hardware directly. The `custom-mmio` feature lets the consuming project inject
+its own read/write implementations, even across the dependency chain, while
+keeping the rest of the safe-mmio API unchanged.
+
+Enable the feature in your `Cargo.toml`:
+
+```toml
+[dependencies]
+safe-mmio = { version = "0.3.0", features = ["custom-mmio"] }
+```
+
+Then implement the `MmioOps` trait and register it with `set_mmio_ops!`:
+
+```rust
+use safe_mmio::custom_mmio::MmioOps;
+
+struct MyBackend;
+
+// SAFETY: Each method performs a single MMIO access of the indicated width.
+unsafe impl MmioOps for MyBackend {
+    unsafe fn read_u8(src: *const u8) -> u8 { /* ... */ }
+    unsafe fn read_u16(src: *const u16) -> u16 { /* ... */ }
+    unsafe fn read_u32(src: *const u32) -> u32 { /* ... */ }
+    unsafe fn read_u64(src: *const u64) -> u64 { /* ... */ }
+    unsafe fn write_u8(dst: *mut u8, value: u8) { /* ... */ }
+    unsafe fn write_u16(dst: *mut u16, value: u16) { /* ... */ }
+    unsafe fn write_u32(dst: *mut u32, value: u32) { /* ... */ }
+    unsafe fn write_u64(dst: *mut u64, value: u64) { /* ... */ }
+}
+
+safe_mmio::set_mmio_ops!(MyBackend);
+```
+
+The `set_mmio_ops!` macro generates `#[no_mangle]` functions that the library resolves via
+`extern "Rust"` declarations. Exactly one call must exist in the final binary; linking fails
+otherwise.
+
+When `custom-mmio` is enabled it replaces both the default `volatile` backend and the `aarch64`
+inline-assembly backend.
+
+**Testing note:** Unit tests (`cargo test --lib --features custom-mmio`) work because the library
+includes a volatile-based `MmioOps` implementation gated on `#[cfg(test)]`. Doc tests build as
+separate binaries and cannot see `#[cfg(test)]` items, so use `--lib` to skip them.
 
 ## Comparison with other MMIO crates
 

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,0 +1,110 @@
+// Copyright 2026 The safe-mmio Authors.
+// This project is dual-licensed under Apache 2.0 and MIT terms.
+// See LICENSE-APACHE and LICENSE-MIT for details.
+
+//! Example demonstrating the use of the safe_mmio crate by accessing
+//! a mock device (=regular RAM).
+//!
+//! This uses the default backend for the current architecture.
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo run --example example
+//! ```
+//!
+//! To enable the custom-mmio backend, run:
+//! ```sh
+//! cargo run --example example --features custom-mmio
+//! ```
+//! An [`MmioOps`] implementation is provided here which simply uses volatile
+//! reads/writes.
+
+use safe_mmio::fields::{ReadPure, ReadWrite};
+use safe_mmio::{UniqueMmioPointer, field};
+
+#[cfg(feature = "custom-mmio")]
+mod custom_ops {
+    struct VolatileOps;
+
+    // SAFETY: Each method performs a single volatile access of the indicated width.
+    unsafe impl safe_mmio::custom_mmio::MmioOps for VolatileOps {
+        unsafe fn read_u8(src: *const u8) -> u8 {
+            // SAFETY: Caller guarantees src is valid and aligned.
+            unsafe { src.read_volatile() }
+        }
+
+        unsafe fn read_u16(src: *const u16) -> u16 {
+            // SAFETY: Caller guarantees src is valid and aligned.
+            unsafe { src.read_volatile() }
+        }
+
+        unsafe fn read_u32(src: *const u32) -> u32 {
+            // SAFETY: Caller guarantees src is valid and aligned.
+            unsafe { src.read_volatile() }
+        }
+
+        unsafe fn read_u64(src: *const u64) -> u64 {
+            // SAFETY: Caller guarantees src is valid and aligned.
+            unsafe { src.read_volatile() }
+        }
+
+        unsafe fn write_u8(dst: *mut u8, value: u8) {
+            // SAFETY: Caller guarantees dst is valid and aligned.
+            unsafe { dst.write_volatile(value) }
+        }
+
+        unsafe fn write_u16(dst: *mut u16, value: u16) {
+            // SAFETY: Caller guarantees dst is valid and aligned.
+            unsafe { dst.write_volatile(value) }
+        }
+
+        unsafe fn write_u32(dst: *mut u32, value: u32) {
+            // SAFETY: Caller guarantees dst is valid and aligned.
+            unsafe { dst.write_volatile(value) }
+        }
+
+        unsafe fn write_u64(dst: *mut u64, value: u64) {
+            // SAFETY: Caller guarantees dst is valid and aligned.
+            unsafe { dst.write_volatile(value) }
+        }
+    }
+
+    safe_mmio::set_mmio_ops!(VolatileOps);
+}
+
+#[repr(C)]
+struct DeviceRegs {
+    status: ReadPure<u32>,
+    control: ReadWrite<u32>,
+    data: ReadWrite<u64>,
+}
+
+fn main() {
+    let mut regs = DeviceRegs {
+        status: ReadPure(0x0000_00FF),
+        control: ReadWrite(0),
+        data: ReadWrite(0),
+    };
+
+    let mut ptr = UniqueMmioPointer::from(&mut regs);
+
+    // Read a pure (side-effect-free) field via shared access.
+    let status = field!(ptr, status).read();
+    println!("status:  {status:#010x}");
+    assert_eq!(status, 0xFF);
+
+    // Write and read back a read-write field.
+    field!(ptr, control).write(0xDEAD_BEEF);
+    let control = field!(ptr, control).read();
+    println!("control: {control:#010x}");
+    assert_eq!(control, 0xDEAD_BEEF);
+
+    // 64-bit read-write field.
+    field!(ptr, data).write(0x0123_4567_89AB_CDEF);
+    let data = field!(ptr, data).read();
+    println!("data:    {data:#018x}");
+    assert_eq!(data, 0x0123_4567_89AB_CDEF);
+
+    println!("all checks passed");
+}

--- a/src/custom_mmio.rs
+++ b/src/custom_mmio.rs
@@ -10,21 +10,39 @@
 //!
 //! # Example
 //!
-//! ```ignore
+//! ```
+//! use safe_mmio::{custom_mmio::MmioOps, set_mmio_ops};
+//!
 //! struct MyMmioBackend;
 //!
-//! unsafe impl safe_mmio::custom_mmio::MmioOps for MyMmioBackend {
-//!     unsafe fn read_u8(src: *const u8) -> u8 { /* ... */ }
-//!     unsafe fn read_u16(src: *const u16) -> u16 { /* ... */ }
-//!     unsafe fn read_u32(src: *const u32) -> u32 { /* ... */ }
-//!     unsafe fn read_u64(src: *const u64) -> u64 { /* ... */ }
-//!     unsafe fn write_u8(dst: *mut u8, value: u8) { /* ... */ }
-//!     unsafe fn write_u16(dst: *mut u16, value: u16) { /* ... */ }
-//!     unsafe fn write_u32(dst: *mut u32, value: u32) { /* ... */ }
-//!     unsafe fn write_u64(dst: *mut u64, value: u64) { /* ... */ }
+//! unsafe impl MmioOps for MyMmioBackend {
+//!     unsafe fn read_u8(src: *const u8) -> u8 {
+//!         src.read_volatile()
+//!     }
+//!     unsafe fn read_u16(src: *const u16) -> u16 {
+//!         src.read_volatile()
+//!     }
+//!     unsafe fn read_u32(src: *const u32) -> u32 {
+//!         src.read_volatile()
+//!     }
+//!     unsafe fn read_u64(src: *const u64) -> u64 {
+//!         src.read_volatile()
+//!     }
+//!     unsafe fn write_u8(dst: *mut u8, value: u8) {
+//!         dst.write_volatile(value);
+//!     }
+//!     unsafe fn write_u16(dst: *mut u16, value: u16) {
+//!         dst.write_volatile(value);
+//!     }
+//!     unsafe fn write_u32(dst: *mut u32, value: u32) {
+//!         dst.write_volatile(value);
+//!     }
+//!     unsafe fn write_u64(dst: *mut u64, value: u64) {
+//!         dst.write_volatile(value);
+//!     }
 //! }
 //!
-//! safe_mmio::set_mmio_ops!(MyMmioBackend);
+//! set_mmio_ops!(MyMmioBackend);
 //! ```
 
 use zerocopy::{FromBytes, Immutable, IntoBytes};
@@ -121,7 +139,11 @@ unsafe extern "Rust" {
 /// # Example
 ///
 /// ```ignore
-/// safe_mmio::set_mmio_ops!(MyMmioBackend);
+/// use safe_mmio::set_mmio_ops;
+///
+/// struct MyMmioBackend;
+///
+/// set_mmio_ops!(MyMmioBackend);
 /// ```
 #[macro_export]
 macro_rules! set_mmio_ops {

--- a/src/custom_mmio.rs
+++ b/src/custom_mmio.rs
@@ -1,0 +1,383 @@
+// Copyright 2026 The safe-mmio Authors.
+// This project is dual-licensed under Apache 2.0 and MIT terms.
+// See LICENSE-APACHE and LICENSE-MIT for details.
+
+//! Custom MMIO backend using consumer-provided read/write implementations.
+//!
+//! When the `custom-mmio` feature is enabled, the consumer must provide an implementation of the
+//! [`MmioOps`] trait and register it using the [`set_mmio_ops!`](crate::set_mmio_ops) macro.
+//! Linking will fail if no implementation is registered.
+//!
+//! # Example
+//!
+//! ```ignore
+//! struct MyMmioBackend;
+//!
+//! unsafe impl safe_mmio::custom_mmio::MmioOps for MyMmioBackend {
+//!     unsafe fn read_u8(src: *const u8) -> u8 { /* ... */ }
+//!     unsafe fn read_u16(src: *const u16) -> u16 { /* ... */ }
+//!     unsafe fn read_u32(src: *const u32) -> u32 { /* ... */ }
+//!     unsafe fn read_u64(src: *const u64) -> u64 { /* ... */ }
+//!     unsafe fn write_u8(dst: *mut u8, value: u8) { /* ... */ }
+//!     unsafe fn write_u16(dst: *mut u16, value: u16) { /* ... */ }
+//!     unsafe fn write_u32(dst: *mut u32, value: u32) { /* ... */ }
+//!     unsafe fn write_u64(dst: *mut u64, value: u64) { /* ... */ }
+//! }
+//!
+//! safe_mmio::set_mmio_ops!(MyMmioBackend);
+//! ```
+
+use zerocopy::{FromBytes, Immutable, IntoBytes};
+
+use crate::{SharedMmioPointer, UniqueMmioPointer};
+use core::mem::size_of;
+use core::ptr::NonNull;
+
+/// Trait for custom MMIO read/write implementations.
+///
+/// Per-size methods are used because MMIO access width matters at the hardware level (e.g. the
+/// GHCB protocol needs to know the exact access size for VMGEXIT calls).
+///
+/// # Safety
+///
+/// Implementations must perform a single MMIO access of the indicated width at the given address.
+/// The pointer is guaranteed to be properly aligned for its type and to point to valid MMIO address
+/// space.
+pub unsafe trait MmioOps {
+    /// Perform an 8-bit MMIO read.
+    ///
+    /// # Safety
+    ///
+    /// `src` must be a valid, aligned pointer to MMIO address space.
+    unsafe fn read_u8(src: *const u8) -> u8;
+
+    /// Perform a 16-bit MMIO read.
+    ///
+    /// # Safety
+    ///
+    /// `src` must be a valid, aligned pointer to MMIO address space.
+    unsafe fn read_u16(src: *const u16) -> u16;
+
+    /// Perform a 32-bit MMIO read.
+    ///
+    /// # Safety
+    ///
+    /// `src` must be a valid, aligned pointer to MMIO address space.
+    unsafe fn read_u32(src: *const u32) -> u32;
+
+    /// Perform a 64-bit MMIO read.
+    ///
+    /// # Safety
+    ///
+    /// `src` must be a valid, aligned pointer to MMIO address space.
+    unsafe fn read_u64(src: *const u64) -> u64;
+
+    /// Perform an 8-bit MMIO write.
+    ///
+    /// # Safety
+    ///
+    /// `dst` must be a valid, aligned pointer to MMIO address space.
+    unsafe fn write_u8(dst: *mut u8, value: u8);
+
+    /// Perform a 16-bit MMIO write.
+    ///
+    /// # Safety
+    ///
+    /// `dst` must be a valid, aligned pointer to MMIO address space.
+    unsafe fn write_u16(dst: *mut u16, value: u16);
+
+    /// Perform a 32-bit MMIO write.
+    ///
+    /// # Safety
+    ///
+    /// `dst` must be a valid, aligned pointer to MMIO address space.
+    unsafe fn write_u32(dst: *mut u32, value: u32);
+
+    /// Perform a 64-bit MMIO write.
+    ///
+    /// # Safety
+    ///
+    /// `dst` must be a valid, aligned pointer to MMIO address space.
+    unsafe fn write_u64(dst: *mut u64, value: u64);
+}
+
+unsafe extern "Rust" {
+    fn __safe_mmio_read_u8(src: *const u8) -> u8;
+    fn __safe_mmio_read_u16(src: *const u16) -> u16;
+    fn __safe_mmio_read_u32(src: *const u32) -> u32;
+    fn __safe_mmio_read_u64(src: *const u64) -> u64;
+    fn __safe_mmio_write_u8(dst: *mut u8, value: u8);
+    fn __safe_mmio_write_u16(dst: *mut u16, value: u16);
+    fn __safe_mmio_write_u32(dst: *mut u32, value: u32);
+    fn __safe_mmio_write_u64(dst: *mut u64, value: u64);
+}
+
+/// Register a [`MmioOps`] implementation as the MMIO backend.
+///
+/// This macro must be called exactly once in the final binary when the `custom-mmio` feature is
+/// enabled. It generates the linker symbols that bridge the [`MmioOps`] trait to the internal
+/// extern function declarations.
+///
+/// # Example
+///
+/// ```ignore
+/// safe_mmio::set_mmio_ops!(MyMmioBackend);
+/// ```
+#[macro_export]
+macro_rules! set_mmio_ops {
+    ($t:ty) => {
+        #[unsafe(no_mangle)]
+        unsafe fn __safe_mmio_read_u8(src: *const u8) -> u8 {
+            // SAFETY: Caller guarantees src is valid and aligned for MMIO.
+            unsafe { <$t as $crate::custom_mmio::MmioOps>::read_u8(src) }
+        }
+
+        #[unsafe(no_mangle)]
+        unsafe fn __safe_mmio_read_u16(src: *const u16) -> u16 {
+            // SAFETY: Caller guarantees src is valid and aligned for MMIO.
+            unsafe { <$t as $crate::custom_mmio::MmioOps>::read_u16(src) }
+        }
+
+        #[unsafe(no_mangle)]
+        unsafe fn __safe_mmio_read_u32(src: *const u32) -> u32 {
+            // SAFETY: Caller guarantees src is valid and aligned for MMIO.
+            unsafe { <$t as $crate::custom_mmio::MmioOps>::read_u32(src) }
+        }
+
+        #[unsafe(no_mangle)]
+        unsafe fn __safe_mmio_read_u64(src: *const u64) -> u64 {
+            // SAFETY: Caller guarantees src is valid and aligned for MMIO.
+            unsafe { <$t as $crate::custom_mmio::MmioOps>::read_u64(src) }
+        }
+
+        #[unsafe(no_mangle)]
+        unsafe fn __safe_mmio_write_u8(dst: *mut u8, value: u8) {
+            // SAFETY: Caller guarantees dst is valid and aligned for MMIO.
+            unsafe { <$t as $crate::custom_mmio::MmioOps>::write_u8(dst, value) }
+        }
+
+        #[unsafe(no_mangle)]
+        unsafe fn __safe_mmio_write_u16(dst: *mut u16, value: u16) {
+            // SAFETY: Caller guarantees dst is valid and aligned for MMIO.
+            unsafe { <$t as $crate::custom_mmio::MmioOps>::write_u16(dst, value) }
+        }
+
+        #[unsafe(no_mangle)]
+        unsafe fn __safe_mmio_write_u32(dst: *mut u32, value: u32) {
+            // SAFETY: Caller guarantees dst is valid and aligned for MMIO.
+            unsafe { <$t as $crate::custom_mmio::MmioOps>::write_u32(dst, value) }
+        }
+
+        #[unsafe(no_mangle)]
+        unsafe fn __safe_mmio_write_u64(dst: *mut u64, value: u64) {
+            // SAFETY: Caller guarantees dst is valid and aligned for MMIO.
+            unsafe { <$t as $crate::custom_mmio::MmioOps>::write_u64(dst, value) }
+        }
+    };
+}
+
+impl<T: FromBytes + IntoBytes> UniqueMmioPointer<'_, T> {
+    /// Performs an MMIO read and returns the value.
+    ///
+    /// If `T` is exactly 1, 2, 4 or 8 bytes long then this will be a single operation. Otherwise
+    /// it will be split into several, reading chunks as large as possible.
+    ///
+    /// Note that this takes `&mut self` rather than `&self` because an MMIO read may cause
+    /// side-effects that change the state of the device.
+    ///
+    /// # Safety
+    ///
+    /// This field must be safe to perform an MMIO read from.
+    pub unsafe fn read_unsafe(&mut self) -> T {
+        // SAFETY: self.regs is always a valid and unique pointer to MMIO address space.
+        unsafe { mmio_read(self.regs) }
+    }
+}
+
+impl<T: Immutable + IntoBytes> UniqueMmioPointer<'_, T> {
+    /// Performs an MMIO write of the given value.
+    ///
+    /// If `T` is exactly 1, 2, 4 or 8 bytes long then this will be a single operation. Otherwise
+    /// it will be split into several, writing chunks as large as possible.
+    ///
+    /// # Safety
+    ///
+    /// This field must be safe to perform an MMIO write to.
+    pub unsafe fn write_unsafe(&mut self, value: T) {
+        // SAFETY: self.regs is always a valid and unique pointer to MMIO address space. The
+        // extern functions are provided by the consumer via set_mmio_ops!().
+        unsafe {
+            match size_of::<T>() {
+                1 => __safe_mmio_write_u8(self.regs.cast().as_ptr(), value.as_bytes()[0]),
+                2 => __safe_mmio_write_u16(self.regs.cast().as_ptr(), convert(value)),
+                4 => __safe_mmio_write_u32(self.regs.cast().as_ptr(), convert(value)),
+                8 => __safe_mmio_write_u64(self.regs.cast().as_ptr(), convert(value)),
+                _ => write_slice(self.regs.cast(), value.as_bytes()),
+            }
+        }
+    }
+}
+
+impl<T: FromBytes + IntoBytes> SharedMmioPointer<'_, T> {
+    /// Performs an MMIO read and returns the value.
+    ///
+    /// If `T` is exactly 1, 2, 4 or 8 bytes long then this will be a single operation. Otherwise
+    /// it will be split into several, reading chunks as large as possible.
+    ///
+    /// # Safety
+    ///
+    /// This field must be safe to perform an MMIO read from, and doing so must not cause any
+    /// side-effects.
+    pub unsafe fn read_unsafe(&self) -> T {
+        // SAFETY: self.regs is always a valid pointer to MMIO address space.
+        unsafe { mmio_read(self.regs) }
+    }
+}
+
+/// Performs an MMIO read and returns the value.
+///
+/// # Safety
+///
+/// The pointer must be valid to perform an MMIO read from.
+unsafe fn mmio_read<T: FromBytes + IntoBytes>(ptr: NonNull<T>) -> T {
+    // SAFETY: ptr is a valid, aligned pointer to MMIO address space. The extern functions are
+    // provided by the consumer via set_mmio_ops!(). For sizes 1/2/4/8 we perform a single
+    // access; for larger sizes we split into chunks. The MaybeUninit is fully initialized before
+    // calling assume_init().
+    unsafe {
+        match size_of::<T>() {
+            1 => convert(__safe_mmio_read_u8(ptr.cast().as_ptr())),
+            2 => convert(__safe_mmio_read_u16(ptr.cast().as_ptr())),
+            4 => convert(__safe_mmio_read_u32(ptr.cast().as_ptr())),
+            8 => convert(__safe_mmio_read_u64(ptr.cast().as_ptr())),
+            _ => {
+                let mut value = T::new_zeroed();
+                read_slice(ptr.cast(), value.as_mut_bytes());
+                value
+            }
+        }
+    }
+}
+
+fn convert<T: Immutable + IntoBytes, U: FromBytes>(value: T) -> U {
+    U::read_from_bytes(value.as_bytes()).unwrap()
+}
+
+/// # Safety
+///
+/// `ptr` must be valid for MMIO writes spanning `slice.len()` bytes.
+unsafe fn write_slice(ptr: NonNull<u8>, slice: &[u8]) {
+    if let Some((first, rest)) = slice.split_at_checked(8) {
+        // SAFETY: Caller guarantees ptr is valid for the full slice length.
+        unsafe {
+            __safe_mmio_write_u64(ptr.cast().as_ptr(), u64::read_from_bytes(first).unwrap());
+            write_slice(ptr.add(8), rest);
+        }
+    } else if let Some((first, rest)) = slice.split_at_checked(4) {
+        // SAFETY: Caller guarantees ptr is valid for the full slice length.
+        unsafe {
+            __safe_mmio_write_u32(ptr.cast().as_ptr(), u32::read_from_bytes(first).unwrap());
+            write_slice(ptr.add(4), rest);
+        }
+    } else if let Some((first, rest)) = slice.split_at_checked(2) {
+        // SAFETY: Caller guarantees ptr is valid for the full slice length.
+        unsafe {
+            __safe_mmio_write_u16(ptr.cast().as_ptr(), u16::read_from_bytes(first).unwrap());
+            write_slice(ptr.add(2), rest);
+        }
+    } else if let [first, rest @ ..] = slice {
+        // SAFETY: Caller guarantees ptr is valid for the full slice length.
+        unsafe {
+            __safe_mmio_write_u8(ptr.as_ptr(), *first);
+            write_slice(ptr.add(1), rest);
+        }
+    }
+}
+
+/// # Safety
+///
+/// `ptr` must be valid for MMIO reads spanning `slice.len()` bytes.
+unsafe fn read_slice(ptr: NonNull<u8>, slice: &mut [u8]) {
+    if let Some((first, rest)) = slice.split_at_mut_checked(8) {
+        // SAFETY: Caller guarantees ptr is valid for the full slice length.
+        unsafe {
+            __safe_mmio_read_u64(ptr.cast().as_ptr())
+                .write_to(first)
+                .unwrap();
+            read_slice(ptr.add(8), rest);
+        }
+    } else if let Some((first, rest)) = slice.split_at_mut_checked(4) {
+        // SAFETY: Caller guarantees ptr is valid for the full slice length.
+        unsafe {
+            __safe_mmio_read_u32(ptr.cast().as_ptr())
+                .write_to(first)
+                .unwrap();
+            read_slice(ptr.add(4), rest);
+        }
+    } else if let Some((first, rest)) = slice.split_at_mut_checked(2) {
+        // SAFETY: Caller guarantees ptr is valid for the full slice length.
+        unsafe {
+            __safe_mmio_read_u16(ptr.cast().as_ptr())
+                .write_to(first)
+                .unwrap();
+            read_slice(ptr.add(2), rest);
+        }
+    } else if let [first, rest @ ..] = slice {
+        // SAFETY: Caller guarantees ptr is valid for the full slice length.
+        unsafe {
+            *first = __safe_mmio_read_u8(ptr.as_ptr());
+            read_slice(ptr.add(1), rest);
+        }
+    }
+}
+
+#[cfg(test)]
+mod testing {
+    /// Default MMIO implementation using volatile access for unit tests.
+    struct VolatileOps;
+
+    // SAFETY: Each method performs a single volatile access of the indicated width.
+    unsafe impl super::MmioOps for VolatileOps {
+        unsafe fn read_u8(src: *const u8) -> u8 {
+            // SAFETY: Caller guarantees src is valid and aligned.
+            unsafe { src.read_volatile() }
+        }
+
+        unsafe fn read_u16(src: *const u16) -> u16 {
+            // SAFETY: Caller guarantees src is valid and aligned.
+            unsafe { src.read_volatile() }
+        }
+
+        unsafe fn read_u32(src: *const u32) -> u32 {
+            // SAFETY: Caller guarantees src is valid and aligned.
+            unsafe { src.read_volatile() }
+        }
+
+        unsafe fn read_u64(src: *const u64) -> u64 {
+            // SAFETY: Caller guarantees src is valid and aligned.
+            unsafe { src.read_volatile() }
+        }
+
+        unsafe fn write_u8(dst: *mut u8, value: u8) {
+            // SAFETY: Caller guarantees dst is valid and aligned.
+            unsafe { dst.write_volatile(value) }
+        }
+
+        unsafe fn write_u16(dst: *mut u16, value: u16) {
+            // SAFETY: Caller guarantees dst is valid and aligned.
+            unsafe { dst.write_volatile(value) }
+        }
+
+        unsafe fn write_u32(dst: *mut u32, value: u32) {
+            // SAFETY: Caller guarantees dst is valid and aligned.
+            unsafe { dst.write_volatile(value) }
+        }
+
+        unsafe fn write_u64(dst: *mut u64, value: u64) {
+            // SAFETY: Caller guarantees dst is valid and aligned.
+            unsafe { dst.write_volatile(value) }
+        }
+    }
+
+    set_mmio_ops!(VolatileOps);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 #![no_std]
 #![deny(clippy::undocumented_unsafe_blocks)]
 #![deny(unsafe_op_in_unsafe_fn)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(all(target_arch = "aarch64", not(feature = "custom-mmio")))]
 mod aarch64_mmio;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,11 +8,13 @@
 #![deny(clippy::undocumented_unsafe_blocks)]
 #![deny(unsafe_op_in_unsafe_fn)]
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", not(feature = "custom-mmio")))]
 mod aarch64_mmio;
+#[cfg(feature = "custom-mmio")]
+pub mod custom_mmio;
 pub mod fields;
 mod physical;
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg(all(not(target_arch = "aarch64"), not(feature = "custom-mmio")))]
 mod volatile_mmio;
 
 use crate::fields::{ReadOnly, ReadPure, ReadPureWrite, ReadWrite, WriteOnly};

--- a/tests/custom_mmio.rs
+++ b/tests/custom_mmio.rs
@@ -91,20 +91,15 @@ fn main() {
 
     // Read a pure (side-effect-free) field via shared access.
     let status = field!(ptr, status).read();
-    println!("status:  {status:#010x}");
     assert_eq!(status, 0xFF);
 
     // Write and read back a read-write field.
     field!(ptr, control).write(0xDEAD_BEEF);
     let control = field!(ptr, control).read();
-    println!("control: {control:#010x}");
     assert_eq!(control, 0xDEAD_BEEF);
 
     // 64-bit read-write field.
     field!(ptr, data).write(0x0123_4567_89AB_CDEF);
     let data = field!(ptr, data).read();
-    println!("data:    {data:#018x}");
     assert_eq!(data, 0x0123_4567_89AB_CDEF);
-
-    println!("all checks passed");
 }


### PR DESCRIPTION
Add a new backend, gated behind the `custom-mmio` Cargo feature, that
allows consumers to provide their own MMIO read/write implementations.

The backend declares a set of extern "Rust" symbols for each access
width (8/16/32/64-bit). Consumers implement the `MmioOps` trait and
call the `set_mmio_ops!` macro, which generates `#[no_mangle]`
functions that satisfy the extern declarations at link time. Linking
fails if no implementation is registered.

When the feature is enabled, both the default volatile backend and the
aarch64 inline-asm backend are disabled.

Doc-tests cannot work with the custom-mmio feature because each doc-test
is a separate binary that would need its own `set_mmio_ops!` call. To
test with the custom backend:

```bash
cargo test --lib --features custom-mmio
```

This feature is useful in certain scenarios where MMIO accesses can't be
done by regular read/writes and require custom handling. For example in
confidential virtual machine contexts, for example under AMD SEV-SNP, if
there is no #VC exception handling for MMIO access provided by the
operating system. In this case the software needs to fall back to
explicit GHCB vmexit calls.

The functions reading/writing slices used for accessing arbitrary types is
copied over from the aarch64 backend. This now opens the possibility for
refactoring and reducing code duplication, which I offer to do as a separate
PR, if desired.

